### PR TITLE
feat: add tweet creation form with server-side validation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import { AddTweet } from "@/components/add-tweet";
 import TweetList from "@/components/tweet-list";
 import db from "@/lib/db";
 import { Prisma } from "@prisma/client";
@@ -27,6 +28,7 @@ export default async function Tweets() {
   const initialTweets = await getInitialTweets();
   return (
     <div>
+      <AddTweet />
       <TweetList initialTweets={initialTweets} />
     </div>
   );

--- a/components/add-tweet/action.ts
+++ b/components/add-tweet/action.ts
@@ -1,0 +1,48 @@
+"use server";
+
+import { z } from "zod";
+
+import db from "@/lib/db";
+import getSession from "@/lib/session";
+
+const tweetSchema = z.object({
+  tweet: z
+    .string()
+    .min(1, { message: "트윗 내용은 최소 1자 이상이어야 합니다." })
+    .max(280, { message: "트윗은 최대 280자까지 작성할 수 있습니다." }),
+});
+
+export async function createTweet(prevState: unknown, formData: FormData) {
+  const validatedFields = await tweetSchema.spa({
+    tweet: formData.get("tweet"),
+  });
+
+  if (!validatedFields.success) {
+    const error = validatedFields.error.flatten().fieldErrors.tweet;
+    return {
+      errors: error ? [...error] : [],
+      success: false,
+    };
+  }
+
+  const session = await getSession();
+
+  if (!session?.id) {
+    return {
+      errors: ["로그인이 필요합니다."],
+      success: false,
+    };
+  }
+
+  await db.tweet.create({
+    data: {
+      tweet: validatedFields.data.tweet,
+      userId: session.id,
+    },
+  });
+
+  return {
+    errors: [],
+    success: true,
+  };
+}

--- a/components/add-tweet/add-tweet.tsx
+++ b/components/add-tweet/add-tweet.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useFormStatus } from "react-dom";
+import { createTweet } from "./action";
+import { useActionState } from "react";
+
+const initialState = {
+  errors: [],
+  success: false,
+};
+
+export function AddTweet() {
+  const [state, action] = useActionState(createTweet, initialState);
+  const { pending } = useFormStatus();
+
+  return (
+    <div className="bg-white p-4 rounded-lg shadow-md mb-4">
+      <form action={action} className="space-y-4">
+        <div>
+          <textarea
+            name="tweet"
+            placeholder="무슨 일이 있나요?"
+            className="w-full p-2 border rounded-md focus:outline-blue-500"
+            rows={3}
+          />
+          {state.errors && (
+            <p className="text-red-500 text-sm mt-1">{state.errors}</p>
+          )}
+        </div>
+
+        <div className="flex justify-between items-center">
+          <button
+            type="submit"
+            disabled={pending}
+            className="bg-blue-500 text-white px-4 py-2 rounded-full hover:bg-blue-600 disabled:opacity-50"
+          >
+            {pending ? "게시 중..." : "트윗"}
+          </button>
+
+          {state.success && (
+            <p
+              className={`
+              text-sm 
+              ${state.success ? "text-green-500" : "text-red-500"}
+            `}
+            >
+              {state.success ? "성공" : state.errors[0]}
+            </p>
+          )}
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/components/add-tweet/index.ts
+++ b/components/add-tweet/index.ts
@@ -1,0 +1,1 @@
+export * from "./add-tweet";


### PR DESCRIPTION
## 추가된 기능
- 트윗 업로드 폼을 포함하는 `<AddTweet />` 컴포넌트 구현
- 트윗 생성을 위한 서버 액션 추가
- Zod를 사용한 트윗 입력 유효성 검사 로직 통합
- Prisma를 활용한 트윗 데이터베이스 저장 기능 구현

## 변경 사항
- 메인 페이지(`/`) 상단에 트윗 작성 폼 추가
- 트윗 작성 및 저장을 위한 클라이언트 및 서버 로직 개발